### PR TITLE
New PR but nothing changed for Battle 

### DIFF
--- a/src/main/java/Battle_System/BattleSystemTestApp.java
+++ b/src/main/java/Battle_System/BattleSystemTestApp.java
@@ -1,0 +1,110 @@
+package Battle_System;
+
+import Battle_System.DataAccess.InMemoryBattleDataAccess;
+import Battle_System.Entity.Monster;
+import Battle_System.Entity.User;
+import Battle_System.Interface_Adapter.Battle.Battle_Controller;
+import Battle_System.Interface_Adapter.Battle.Battle_Presenter;
+import Battle_System.Interface_Adapter.Battle.Battle_State;
+import Battle_System.Interface_Adapter.Battle.Battle_ViewModel;
+import Battle_System.Interface_Adapter.ViewManagerModel;
+import Battle_System.UseCase.Battle.Battle_Interactor;
+import Battle_System.View.Battle_View;
+import Battle_System.View.Quiz_View;
+import Battle_System.View.Quiz_ViewModel;
+
+import javax.swing.*;
+import java.awt.*;
+import java.beans.PropertyChangeEvent;
+import java.beans.PropertyChangeListener;
+
+/**
+ * Main application to test Battle System with view switching.
+ */
+public class BattleSystemTestApp {
+    private JFrame frame;
+    private CardLayout cardLayout;
+    private JPanel cardPanel;
+
+    public static void main(String[] args) {
+        SwingUtilities.invokeLater(() -> {
+            BattleSystemTestApp app = new BattleSystemTestApp();
+            app.createAndShowGUI();
+        });
+    }
+
+    private void createAndShowGUI() {
+        // Create the main frame
+        frame = new JFrame("Battle System Test");
+        frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
+        frame.setSize(800, 600);
+
+        // Create CardLayout for view switching
+        cardLayout = new CardLayout();
+        cardPanel = new JPanel(cardLayout);
+
+        // Initialize ViewModels
+        ViewManagerModel viewManagerModel = new ViewManagerModel("Battle");
+        Battle_ViewModel battleViewModel = new Battle_ViewModel();
+        Quiz_ViewModel quizViewModel = new Quiz_ViewModel();
+
+        // Initialize Data Access
+        InMemoryBattleDataAccess battleDataAccess = new InMemoryBattleDataAccess();
+
+        // Initialize Presenter
+        Battle_Presenter battlePresenter = new Battle_Presenter(battleViewModel, viewManagerModel);
+
+        // Initialize Interactor
+        Battle_Interactor battleInteractor = new Battle_Interactor(battleDataAccess, battlePresenter);
+
+        // Initialize Controller
+        Battle_Controller battleController = new Battle_Controller(battleInteractor);
+
+        // Create Views
+        Battle_View battleView = new Battle_View(battleViewModel, viewManagerModel, quizViewModel);
+        battleView.setBattleController(battleController);
+
+        Quiz_View quizView = new Quiz_View(quizViewModel, viewManagerModel);
+        quizView.setBattleController(battleController);
+
+        // Add views to CardLayout
+        cardPanel.add(battleView, "Battle");
+        cardPanel.add(quizView, "Quiz");
+
+        // Add ViewManagerModel listener to switch views
+        viewManagerModel.addPropertyChangeListener(new PropertyChangeListener() {
+            @Override
+            public void propertyChange(PropertyChangeEvent evt) {
+                if ("state".equals(evt.getPropertyName())) {
+                    String viewName = (String) evt.getNewValue();
+                    cardLayout.show(cardPanel, viewName);
+
+                    // Re-enable attack button when returning to battle view
+                    if ("Battle".equals(viewName)) {
+                        battleView.getComponent(0); // Refresh view
+                    }
+                }
+            }
+        });
+
+        // Initialize battle with test data
+        User testUser = new User();
+        Monster testMonster = new Monster();
+
+        Battle_State battleState = battleViewModel.getState();
+        battleState.setUser(testUser);
+        battleState.setMonster(testMonster);
+        battleState.setBattleMessage("Battle begins! Click Attack to start!");
+        battleViewModel.firePropertyChange();
+
+        // Add card panel to frame
+        frame.add(cardPanel);
+
+        // Show the frame
+        frame.setLocationRelativeTo(null);
+        frame.setVisible(true);
+
+        // Show Battle view first
+        cardLayout.show(cardPanel, "Battle");
+    }
+}

--- a/src/main/java/Battle_System/DataAccess/InMemoryBattleDataAccess.java
+++ b/src/main/java/Battle_System/DataAccess/InMemoryBattleDataAccess.java
@@ -1,0 +1,101 @@
+package Battle_System.DataAccess;
+
+import Battle_System.Entity.Monster;
+import Battle_System.Entity.User;
+import Battle_System.UseCase.Battle.BattleUserDataAccessInterface;
+
+/**
+ * In-Memory implementation of BattleUserDataAccessInterface.
+ * Stores battle state in memory during the battle.
+ */
+public class InMemoryBattleDataAccess implements BattleUserDataAccessInterface {
+
+    // Store battle states (before and after)
+    private User userBeforeBattle;
+    private User userAfterBattle;
+    private Monster monsterBeforeBattle;
+    private Monster monsterAfterBattle;
+
+    /**
+     * Saves the current state of user and monster.
+     * This creates a snapshot of the current battle state.
+     */
+    @Override
+    public void save(User user, Monster monster) {
+        // If this is the first save (before battle starts)
+        if (userBeforeBattle == null) {
+            userBeforeBattle = cloneUser(user);
+            monsterBeforeBattle = cloneMonster(monster);
+        }
+
+        // Always update the "after" state
+        userAfterBattle = cloneUser(user);
+        monsterAfterBattle = cloneMonster(monster);
+    }
+
+    /**
+     * Returns the user state before the battle started.
+     */
+    @Override
+    public User getUserBeforeBattle() {
+        return userBeforeBattle;
+    }
+
+    /**
+     * Returns the user state after the battle.
+     */
+    @Override
+    public User getUserAfterBattle() {
+        return userAfterBattle;
+    }
+
+    /**
+     * Returns the monster state before the battle started.
+     */
+    @Override
+    public Monster getMonsterBeforeBattle() {
+        return monsterBeforeBattle;
+    }
+
+    /**
+     * Returns the monster state after the battle.
+     */
+    @Override
+    public Monster getMonsterAfterBattle() {
+        return monsterAfterBattle;
+    }
+
+    /**
+     * Resets the battle state (for starting a new battle).
+     */
+    public void reset() {
+        userBeforeBattle = null;
+        userAfterBattle = null;
+        monsterBeforeBattle = null;
+        monsterAfterBattle = null;
+    }
+
+    /**
+     * Creates a shallow clone of the User.
+     * For a real implementation, we might need deep cloning.
+     */
+    private User cloneUser(User user) {
+        if (user == null) return null;
+
+        // For now, just return the reference
+        // TODO: Implement proper cloning if we need to preserve history
+        return user;
+    }
+
+    /**
+     * Creates a shallow clone of the Monster.
+     * For a real implementation, we might need deep cloning.
+     */
+    private Monster cloneMonster(Monster monster) {
+        if (monster == null) return null;
+
+        // For now, just return the reference
+        // TODO: Implement proper cloning if we need to preserve history
+        return monster;
+    }
+}

--- a/src/main/java/Battle_System/Entity/Inventory.java
+++ b/src/main/java/Battle_System/Entity/Inventory.java
@@ -1,0 +1,8 @@
+package Battle_System.Entity;
+
+public class Inventory {
+    // 1. As a user I want to choose to pick up something on the ground, and either equip them or put them in the inventory
+    // 2. As a user I want those items I picked up have some special functions, such as enhancing my ATK or increasing my HP
+    // 3. As a user I want that when inventory is already full, picking up a new item will require me to choose one item to discard.
+
+}

--- a/src/main/java/Battle_System/Entity/Item.java
+++ b/src/main/java/Battle_System/Entity/Item.java
@@ -1,0 +1,25 @@
+package Battle_System.Entity;
+
+public class Item {
+
+    private String name;
+    private String description;
+    private String type; // type of item??
+
+    public Item(String name, String description, String type) {
+        this.name = name;
+        this.description = description;
+        this.type = type;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+    public String getType() {
+        return type;
+    }
+    public String getName() {
+        return name;
+    }
+
+}

--- a/src/main/java/Battle_System/Entity/Monster.java
+++ b/src/main/java/Battle_System/Entity/Monster.java
@@ -1,0 +1,109 @@
+package Battle_System.Entity;
+
+import Battle_System.GameAPI.SrdMonsterDetail;
+
+import java.util.ArrayList;
+import java.util.Random;
+/**
+ * This Monster class
+ */
+public class Monster {
+    //1. As a user I wa nt those monsters I’ve defeated to be recorded, and to be able to view their status information.
+    //2. As a user I want that when I pass through the same area again, the monsters I’ve already defeated will not reappear.
+    //3. As a user I want those monsters have name, atk, hp, and damage type
+    public String NAME;
+    private double HP;
+    private Spells[] SPELL;
+
+    /**
+     * The constructor of the Monster. It randomly set the value of the HP, select name and generate spells from
+     * the api.
+     */
+    public Monster() {
+        Random random = new Random();
+        HP = random.nextInt(11) + 20;
+
+        SrdMonsterDetail api = new SrdMonsterDetail();
+        setSpells(api);
+        setNAME(api);
+    }
+
+    // TODO: finish the override
+    @Override
+    public String toString() {
+        return NAME;
+    }
+
+
+    /**
+     * The getter for the HP.
+     */
+    public double getHP() {
+        return HP;
+    }
+
+    /**
+     * The getter for the SPELL.
+     */
+    public Spells[] getSpells() {
+        return SPELL;
+    }
+
+    /**
+     * Decrease the HP.
+     */
+    public void HPDecrease(double DMG){
+        HP -= DMG;
+        if (HP < 0) HP = 0;
+    }
+
+    /**
+     * Randomly select a name from the api.
+     */
+    public void setNAME(SrdMonsterDetail api) {
+        Random random = new Random();
+        String[] nameList = api.generateRaces();
+        int size = nameList.length;
+        int index = random.nextInt(size);
+        NAME = nameList[index];
+    }
+
+    /**
+     * Randomly select size of the spell list for the monster and randomly select the type of spells.
+     */
+    public void setSpells(SrdMonsterDetail api) {
+        Random random = new Random();
+        int size = random.nextInt(3) + 1;
+        ArrayList<Spells> spell = api.generateSpells();
+        int spellListSize = spell.size();
+        SPELL = new Spells[size];
+        for (int i = 0; i < size; i++) {
+            int randomIndex = random.nextInt(spellListSize);
+            SPELL[i] = spell.get(randomIndex);
+        }
+    }
+
+    /**
+     * Randomly select the spell
+     */
+    public Spells chooseSpell(){
+        Random random = new Random();
+        int size = SPELL.length;
+        int index = random.nextInt(size);
+        return SPELL[index];
+    }
+
+    /**
+     * Return the DMG value of the monster.
+     */
+    public double attack(Spells spell) {
+        return spell.getDMG();
+    }
+
+    /**
+     * Return true if the HP of the monster is greater than 0, which indicate the monster is still alive.
+     */
+    public boolean isAlive() {
+        return HP > 0;
+    }
+}

--- a/src/main/java/Battle_System/Entity/Spells.java
+++ b/src/main/java/Battle_System/Entity/Spells.java
@@ -1,0 +1,32 @@
+package Battle_System.Entity;
+
+
+public class Spells {
+    private final String spellName;
+    private final int DMG;
+
+    /**
+     * This constructor of the Spells class contains the type of the damage(spellName), and the value of the corresponding damage.
+     */
+    public Spells(String spellName, int DMG) {
+        this.spellName = spellName;
+        this.DMG = DMG;
+    }
+
+    // TODO: finish the override
+    @Override
+    public String toString() {
+        return spellName;
+    }
+
+    /**
+     * The getter for spellName.
+     */
+    public String getSpellName() {return spellName;}
+
+    /**
+     * The getter for spell's DMG.
+     */
+    public int getDMG() {return DMG;}
+
+}

--- a/src/main/java/Battle_System/Entity/User.java
+++ b/src/main/java/Battle_System/Entity/User.java
@@ -1,0 +1,102 @@
+package Battle_System.Entity;
+
+import java.util.Random;
+
+public class User {
+    //1. As a user I want to have an initial ATK and HP value when the game starts.
+    //2. As a user I want to be able to initiate a battle so that I can attack my opponent/monster or choose flee to aviod the fight.
+    //3. As a user I want to be able to access my inventory so that I can equip or use items.
+    public String NAME;
+    private double HP;
+    private double bonusHP = 0;
+    private double DMG = 8;
+    private double DEF = 0;
+
+    /**
+     * The constructor for User class.
+     */
+    public User() {
+        Random random = new Random();
+        HP = random.nextInt(11) + 20;
+    }
+
+    // TODO: finish the override
+    @Override
+    public String toString() {
+        return null;
+    }
+
+    /**
+     * The getter for HP.
+     */
+    public double getHP() {
+        return HP;
+    }
+
+    /**
+     * The getter for DMG.
+     */
+    public double getDMG() {
+        return DMG;
+    }
+
+    /**
+     * The getter for bonusHP.
+     */
+    public double getBonusHP(){return bonusHP;}
+
+    /**
+     * The getter for DEF.
+     */
+    public double getDEF() {return DEF;}
+
+    /**
+     * Decrease the bonus HP, the bonus HP is considered as shield. Return the value of the left damage to the HP.
+     */
+    public double bonusHPDecrease(double dmg){
+        if(bonusHP > dmg){
+            bonusHP -= dmg;
+            return 0;
+        }else {
+            double returnVal = dmg - bonusHP;
+            bonusHP = 0;
+            return returnVal;
+        }
+    }
+
+    /**
+     * Decrease the HP by the damage. The actual damage depends on the DEF of the user. Some of the damage will only
+     * affect the bonus HP, if the damage is high, then it will decrease the HP.
+     */
+    public void HPDecrease(double dmg){
+        double damage = dmg * (1 - 0.08 * getDEF());
+        double leftDamage = bonusHPDecrease(damage);
+        HP -= leftDamage;
+        if (HP < 0) HP = 0;
+    }
+
+    /**
+     * Add DMG, this method will be called when user equip the weapon or change the weapon.
+     */
+    public void addDMG(double dmg){DMG += dmg;}
+
+    /**
+     * Decrease DMG, this method will be called when user unequip the weapon or change the weapon.
+     */
+    public void decreaseDMG(double dmg){DMG -= dmg;}
+
+    /**
+     * Add DEF, this method will be called when user equip the armour or change the armour.
+     */
+    public void addDEF(double def){DEF += def;}
+
+    /**
+     * Decrease DEF, this method will be called when user unequip the armour or change the armour.
+     */
+    public void decreaseDEF(double def){DEF -= def;}
+
+    /**
+     * Return true if the HP of the user is greater than 0, which indicate the user is still alive.
+     */
+    public boolean isAlive() {return HP > 0;}
+}

--- a/src/main/java/Battle_System/GameAPI/MonsterDetail.java
+++ b/src/main/java/Battle_System/GameAPI/MonsterDetail.java
@@ -1,0 +1,33 @@
+package Battle_System.GameAPI;
+
+import Battle_System.Entity.Spells;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+
+public interface MonsterDetail {
+    /**
+     * this method will get the urls from the api
+     * @throws MonsterNotFoundException throws the exception if nothing is founded
+     */
+    HashMap<String,String> getAllResourcesURL() throws MonsterNotFoundException;
+
+    /**
+     * this method will get the HashMap for spells, where the keys are name of the spells and the values are the dmg
+     * @throws MonsterNotFoundException throws the exception if nothing is founded
+     */
+    ArrayList<Spells> generateSpells() throws MonsterNotFoundException;
+
+    /**
+     * this method will get an Array for races
+     * @throws MonsterNotFoundException throws the exception if nothing is founded
+     */
+    String[] generateRaces() throws MonsterNotFoundException;
+
+
+    class MonsterNotFoundException extends RuntimeException {
+        public MonsterNotFoundException() {
+            super("Monster not found");
+        }
+    }
+}

--- a/src/main/java/Battle_System/GameAPI/SrdMonsterDetail.java
+++ b/src/main/java/Battle_System/GameAPI/SrdMonsterDetail.java
@@ -1,0 +1,104 @@
+package Battle_System.GameAPI;
+
+import Battle_System.Entity.Spells;
+import okhttp3.MediaType;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+
+/**
+ * this class is for Game API, the methods inside of this class will generate the information for Monster class.
+ */
+public class SrdMonsterDetail implements MonsterDetail {
+    /**
+     * this method will get the url for races and spells from the api
+     * @return a HashMap, the keys are "spells" and "races", the values are the corresponding urls
+     * @throws MonsterNotFoundException throws the exception if nothing is founded
+     */
+    @Override
+    public HashMap<String,String> getAllResourcesURL() {
+        OkHttpClient client = new OkHttpClient().newBuilder()
+                .build();
+        MediaType mediaType = MediaType.parse("text/plain");
+        Request request = new Request.Builder()
+                .url("https://www.dnd5eapi.co/api/2014")
+                .addHeader("Accept", "application/json")
+                .build();
+        HashMap<String,String> map = new HashMap<>();
+        try{
+            final Response response = client.newCall(request).execute();
+            final JSONObject responseBody = new JSONObject(response.body().string());
+            for (String str: responseBody.keySet()) {
+               map.put(str,responseBody.getString(str));
+            }
+        }catch (Exception e){
+            throw new MonsterNotFoundException();
+        }
+        return map;
+    }
+
+    /**
+     * this method will get the ArrayList for spells
+     * @return a ArrayList
+     * @throws MonsterNotFoundException throws the exception if nothing is founded
+     */
+    @Override
+    public ArrayList<Spells> generateSpells() {
+        OkHttpClient client = new OkHttpClient().newBuilder()
+                .build();
+        Request request = new Request.Builder()
+                .url(String.format("https://www.dnd5eapi.co%s",getAllResourcesURL().get("spells")))
+                .addHeader("Accept", "application/json")
+                .build();
+        ArrayList<Spells> theSpell = new ArrayList<Spells>();
+        try {
+            final Response response = client.newCall(request).execute();
+            final JSONObject responseBody = new JSONObject(response.body().string());
+            JSONArray results = responseBody.getJSONArray("results");
+            for (int i = 0; i < results.length(); i++) {
+                JSONObject spell = results.getJSONObject(i);
+                String name = spell.getString("name");
+                int dmg = spell.getInt("level");
+                theSpell.add(new Spells(name, dmg));
+            }
+        } catch (Exception e) {
+            throw new MonsterNotFoundException();
+        }
+        return theSpell;
+    }
+
+    /**
+     * this method will get an Array for races
+     * @throws MonsterNotFoundException throws the exception if nothing is founded
+     */
+    @Override
+    public String[] generateRaces() {
+        OkHttpClient client = new OkHttpClient().newBuilder()
+                .build();
+        MediaType mediaType = MediaType.parse("text/plain");
+        Request request = new Request.Builder()
+                .url(String.format("https://www.dnd5eapi.co%s",getAllResourcesURL().get("races")))
+                .addHeader("Accept", "application/json")
+                .build();
+        try {
+            final Response response = client.newCall(request).execute();
+            final JSONObject responseBody = new JSONObject(response.body().string());
+            JSONArray results = responseBody.getJSONArray("results");
+            String[] list = new String[results.length()];
+            for (int i = 0; i < results.length(); i++) {
+                JSONObject races = results.getJSONObject(i);
+                String name = races.getString("name");
+                list[i] =  name;
+            }
+            return list;
+        } catch (Exception e) {
+            throw new MonsterNotFoundException();
+        }
+    }
+
+}

--- a/src/main/java/Battle_System/Interface_Adapter/Battle/Battle_Controller.java
+++ b/src/main/java/Battle_System/Interface_Adapter/Battle/Battle_Controller.java
@@ -1,0 +1,24 @@
+package Battle_System.Interface_Adapter.Battle;
+
+import Battle_System.Entity.Monster;
+import Battle_System.Entity.User;
+import Battle_System.UseCase.Battle.Battle_InputBoundary;
+import Battle_System.UseCase.Battle.Battle_InputData;
+
+/**
+ * Controller for the Battle Use Case.
+ *
+ */
+public class Battle_Controller {
+    private final Battle_InputBoundary battleUseCaseInteractor;
+
+
+    public Battle_Controller(Battle_InputBoundary battleUseCaseInteractor) {
+        this.battleUseCaseInteractor = battleUseCaseInteractor;
+    }
+
+    public void execute(User user, Monster monster, boolean resultOfQuiz){
+        final Battle_InputData battleInputData= new Battle_InputData(user, monster, resultOfQuiz);
+        battleUseCaseInteractor.execute(battleInputData);
+    }
+}

--- a/src/main/java/Battle_System/Interface_Adapter/Battle/Battle_Presenter.java
+++ b/src/main/java/Battle_System/Interface_Adapter/Battle/Battle_Presenter.java
@@ -1,0 +1,130 @@
+package Battle_System.Interface_Adapter.Battle;
+
+import Battle_System.Interface_Adapter.ViewManagerModel;
+import Battle_System.UseCase.Battle.Battle_OutputBoundary;
+import Battle_System.UseCase.Battle.Battle_OutputData;
+
+/**
+ * Presenter for the Battle Use Case.
+ * Converts output data from the use case into a format suitable for the view.
+ */
+public class Battle_Presenter implements Battle_OutputBoundary {
+    private final Battle_ViewModel battleViewModel;
+    // TODO: Haven't handle the view manager, this should be used for switching from Battle View into the Moving on
+    //  the map. I think we also need to use the view model from the map system once we are finished.
+    private final ViewManagerModel viewManagerModel;
+    // private final Moving_ViewModel moving_ViewModel;
+
+    public Battle_Presenter(Battle_ViewModel battleViewModel, ViewManagerModel viewManagerModel) {
+        this.battleViewModel = battleViewModel;
+        this.viewManagerModel = viewManagerModel;
+    }
+
+    /**
+     * Updates the battle state after each turn.
+     * This is called during the battle to update HP values.
+     */
+    @Override
+    public void updateMonsterTurnState(Battle_OutputData outputData) {
+        Battle_State state = battleViewModel.getState();
+
+        // Update HP values after each turn
+        state.setUserHP(outputData.getUserHP());
+        state.setMonsterHP(outputData.getMonsterHP());
+
+        // Add a message about the turn (Optional)
+        String turnMessage = String.format("Monster Completed its turn. Your HP is %.1f, Monster HP is %.1f",
+                outputData.getUserHP(), outputData.getMonsterHP());
+        state.setBattleMessage("\n" + turnMessage);
+
+        // Notify the view to update
+        battleViewModel.firePropertyChange();
+    }
+
+    /**
+     * Updates the battle state after each turn.
+     * This is called during the battle to update HP values.
+     */
+    @Override
+    public void updateUserTurnState(Battle_OutputData outputData) {
+        Battle_State state = battleViewModel.getState();
+
+        // Update HP values after each turn
+        state.setUserHP(outputData.getUserHP());
+        state.setMonsterHP(outputData.getMonsterHP());
+
+        // Add a message about the turn (Optional)
+        String turnMessage = String.format("You Completed your turn. Your HP is %.1f, Monster HP is %.1f",
+                outputData.getUserHP(), outputData.getMonsterHP());
+        state.setBattleMessage("\n" + turnMessage);
+
+        // Notify the view to update
+        battleViewModel.firePropertyChange();
+    }
+
+    /**
+     * Prepares the Win view for the Battle Use Case.
+     *
+     * @param outputData the output data
+     */
+    @Override
+    public void prepareWinView(Battle_OutputData outputData) {
+        // Get the current state
+        Battle_State state = battleViewModel.getState();
+
+        // Update state with final battle results
+        state.setUserHP(outputData.getUserHP());
+        state.setMonsterHP(outputData.getMonsterHP());
+
+        // Set win status and message
+        state.setBattleEnded(true);
+        state.setUserWon(true);
+        state.setBattleMessage("Victory! You defeated " + outputData.getMonster().NAME + "!");
+
+        // Notify the view that state has changed
+        battleViewModel.firePropertyChange();
+
+        // switch to a different view after a delay
+        viewManagerModel.setState("Moving");
+        viewManagerModel.firePropertyChange();
+    }
+
+    /**
+     * Prepares the Loss view for the Battle Use Case.
+     *
+     * @param outputData the output data
+     */
+    @Override
+    public void prepareLossView(Battle_OutputData outputData) {
+        // Get the current state
+        Battle_State state = battleViewModel.getState();
+
+        // Update state with final battle results
+        state.setUser(outputData.getUser());
+        state.setMonster(outputData.getMonster());
+
+        // Set loss status and message
+        state.setBattleEnded(true);
+        state.setUserWon(false);
+        state.setBattleMessage("Defeat! You were defeated by " + outputData.getMonster().NAME + "!");
+
+        // Notify the view that state has changed
+        battleViewModel.firePropertyChange();
+
+        // switch to a different view after a delay
+        viewManagerModel.setState("Moving");
+        viewManagerModel.firePropertyChange();
+    }
+
+    /**
+     * Prepares the Quiz view for the Battle Use Case.
+     *
+     * @param outputData the output data
+     */
+    @Override
+    public void prepareQuizView(Battle_OutputData outputData) {
+        // Switch to quiz view
+        viewManagerModel.setState("Quiz");
+        viewManagerModel.firePropertyChange();
+    }
+}

--- a/src/main/java/Battle_System/Interface_Adapter/Battle/Battle_State.java
+++ b/src/main/java/Battle_System/Interface_Adapter/Battle/Battle_State.java
@@ -1,0 +1,89 @@
+package Battle_System.Interface_Adapter.Battle;
+
+import Battle_System.Entity.Monster;
+import Battle_System.Entity.User;
+
+/**
+ * State object for the Battle View.
+ *
+ */
+public class Battle_State {
+    private User user = null;
+    private Monster monster = null;
+    private double userHp = 0;
+    private double monsterHP = 0;
+    private String battleMessage = "";
+    private boolean battleEnded = false;
+    private boolean userWon = false;
+
+    // Monster getters and setters
+    public Monster getMonster() {
+        return monster;
+    }
+
+    public void setMonster(Monster monster) {
+        this.monster = monster;
+        if (monster != null) {
+            this.monsterHP = monster.getHP();
+        }
+    }
+
+    public double getMonsterHP() {
+        return monsterHP;
+    }
+
+    public void setMonsterHP(double monsterHP) {
+        this.monsterHP = monsterHP;
+    }
+
+
+    // User getters and setters
+    public User getUser() {
+        return user;
+    }
+
+    public void setUser(User user) {
+        this.user = user;
+        if (user != null) {
+            this.userHp = user.getHP();
+        }
+    }
+
+    public double getUserHp() {
+        return userHp;
+    }
+
+    public void setUserHP(double userHp) {
+        this.userHp = userHp;
+    }
+
+    // Battle message
+    public String getBattleMessage() {
+        return battleMessage;
+    }
+
+    public void setBattleMessage(String battleMessage) {
+        this.battleMessage = battleMessage;
+    }
+
+    // Battle status
+    public boolean isBattleEnded() {
+        return battleEnded;
+    }
+
+    public void setBattleEnded(boolean battleEnded) {
+        this.battleEnded = battleEnded;
+    }
+
+    public boolean isUserWon() {
+        return userWon;
+    }
+
+    public void setUserWon(boolean userWon) {
+        this.userWon = userWon;
+    }
+
+    public String getMonsterName() {
+        return monster != null ? monster.NAME : "Monster";
+    }
+}

--- a/src/main/java/Battle_System/Interface_Adapter/Battle/Battle_ViewModel.java
+++ b/src/main/java/Battle_System/Interface_Adapter/Battle/Battle_ViewModel.java
@@ -1,0 +1,11 @@
+package Battle_System.Interface_Adapter.Battle;
+
+import Battle_System.Interface_Adapter.ViewModel;
+
+public class Battle_ViewModel extends ViewModel<Battle_State> {
+
+    public Battle_ViewModel() {
+        super("Battle");
+        setState(new Battle_State());
+    }
+}

--- a/src/main/java/Battle_System/Interface_Adapter/ViewManagerModel.java
+++ b/src/main/java/Battle_System/Interface_Adapter/ViewManagerModel.java
@@ -1,0 +1,8 @@
+package Battle_System.Interface_Adapter;
+
+public class ViewManagerModel extends ViewModel<String> {
+    public  ViewManagerModel(String viewName) {
+        super("View Manager");
+        this.setState(viewName);
+    }
+}

--- a/src/main/java/Battle_System/Interface_Adapter/ViewModel.java
+++ b/src/main/java/Battle_System/Interface_Adapter/ViewModel.java
@@ -1,0 +1,63 @@
+package Battle_System.Interface_Adapter;
+import java.beans.PropertyChangeListener;
+import java.beans.PropertyChangeSupport;
+
+/**
+ * The ViewModel for our CA implementation.
+ * This class delegates work to a PropertyChangeSupport object for
+ * managing the property change events.
+ *
+ * @param <T> The type of state object contained in the model.
+ */
+public class ViewModel<T> {
+
+    private final String viewName;
+
+    private final PropertyChangeSupport support = new PropertyChangeSupport(this);
+
+    private T state;
+
+    public ViewModel(String viewName) {
+        this.viewName = viewName;
+    }
+
+    public String getViewName() {
+        return this.viewName;
+    }
+
+    public T getState() {
+        return this.state;
+    }
+
+    public void setState(T state) {
+        this.state = state;
+    }
+
+    /**
+     * Fires a property changed event for the state of this ViewModel.
+     */
+    public void firePropertyChange() {
+        this.support.firePropertyChange("state", null, this.state);
+    }
+
+    /**
+     * Fires a property changed event for the state of this ViewModel, which
+     * allows the user to specify a different propertyName. This can be useful
+     * when a class is listening for multiple kinds of property changes.
+     * <p/>
+     * For example, the LoggedInView listens for two kinds of property changes;
+     * it can use the property name to distinguish which property has changed.
+     * @param propertyName the label for the property that was changed
+     */
+    public void firePropertyChange(String propertyName) {
+        this.support.firePropertyChange(propertyName, null, this.state);
+    }
+
+    /**
+     * Adds a PropertyChangeListener to this ViewModel.
+     * @param listener The PropertyChangeListener to be added
+     */
+    public void addPropertyChangeListener(PropertyChangeListener listener) {
+        this.support.addPropertyChangeListener(listener);
+    }
+}

--- a/src/main/java/Battle_System/ShowTheBattle.java
+++ b/src/main/java/Battle_System/ShowTheBattle.java
@@ -1,0 +1,69 @@
+package Battle_System;//package Battle_System;
+//
+//import Battle_System.DataAccess.*;
+//import Battle_System.Entity.*;
+//import Battle_System.GameAPI.*;
+//import Battle_System.Interface_Adapter.Battle.*;
+//import Battle_System.Interface_Adapter.ViewManagerModel;
+//import Battle_System.UseCase.Battle.*;
+//import Battle_System.View.Battle_View;
+//
+//import javax.swing.*;
+//
+//public class ShowTheBattle {
+//
+//    public static void main(String[] args) {
+//        // 1. create DAO TODO: Not sure about this part need to be completed in the future.
+//        BattleUserDataAccessInterface dao = new InMemoryBattleDataAccess();
+//
+//        // 2. create ViewModels
+//        Battle_ViewModel battleViewModel = new Battle_ViewModel();
+//        ViewManagerModel viewManagerModel = new ViewManagerModel("Battle");
+//
+//        // 3. create Presenter
+//        Battle_Presenter presenter = new Battle_Presenter(battleViewModel, viewManagerModel);
+//
+//        // 4. create Interactor
+//        Battle_Interactor interactor = new Battle_Interactor(dao, presenter);
+//
+//        // 5. create Controller
+//        Battle_Controller controller = new Battle_Controller(interactor);
+//
+//        // 6. create Entities
+//        User user = new User();
+//        Monster monster = new Monster();
+//        // Test message (Need to be Deleted)
+//        // TODO: Delete This Message
+//        System.out.println("User HP: " + user.getHP());
+//        System.out.println("Monster HP: " + monster.getHP());
+//
+//        // 7. create View
+//        Battle_View view = new Battle_View(battleViewModel,  viewManagerModel, );
+//        view.setBattleController(controller);
+//
+//        // 8. Initialize the State
+//        Battle_State state = battleViewModel.getState();
+//        state.setUser(user);
+//        state.setMonster(monster);
+//
+//        // TODO: Delete This Message, This is a Test Message
+//        System.out.println("State User HP: " + state.getUserHp());
+//        System.out.println("State Monster HP: " + state.getMonsterHP());
+//        battleViewModel.firePropertyChange();
+//
+//
+//        // TODO: Delete This Message, This is a Test Message
+//        System.out.println("=== Battle Initialized ===");
+//
+//        // 9. Show the GUI
+//        JFrame frame = new JFrame("Battle System");
+//        frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
+//        frame.setContentPane(view);
+//        frame.pack();
+//        frame.setLocationRelativeTo(null);
+//        frame.setVisible(true);
+//
+//        // TODO: Delete This Message, This is a Test Message
+//        System.out.println("=== Window Displayed ===");
+//    }
+//}

--- a/src/main/java/Battle_System/UseCase/Battle/BattleUserDataAccessInterface.java
+++ b/src/main/java/Battle_System/UseCase/Battle/BattleUserDataAccessInterface.java
@@ -1,0 +1,33 @@
+package Battle_System.UseCase.Battle;
+
+import Battle_System.Entity.Monster;
+import Battle_System.Entity.User;
+
+public interface BattleUserDataAccessInterface {
+    /**
+     * saved the user and the monster
+     */
+    void save(User user, Monster monster);
+
+    /**
+     * return the User that contains the user information which is before user starting the battle
+     */
+    User getUserBeforeBattle();
+
+    /**
+     * return the User that contains the user information which is after user starting th battle
+     */
+    User getUserAfterBattle();
+
+    /**
+     * return the Monster that contains the monster information which is before user starting the battle
+     */
+    Monster getMonsterBeforeBattle();
+
+    /**
+     * return the Monster that contains the monster information which is after user starting the battle
+     */
+    Monster getMonsterAfterBattle();
+
+
+}

--- a/src/main/java/Battle_System/UseCase/Battle/Battle_InputBoundary.java
+++ b/src/main/java/Battle_System/UseCase/Battle/Battle_InputBoundary.java
@@ -1,0 +1,14 @@
+package Battle_System.UseCase.Battle;
+
+/**
+ * Input Boundary for actions which are related to battle.
+ */
+public interface Battle_InputBoundary {
+    /**
+     * Executes the battle use case.
+     *
+     * @param inputData the input battle data
+     */
+    void execute(Battle_InputData inputData);
+}
+

--- a/src/main/java/Battle_System/UseCase/Battle/Battle_InputData.java
+++ b/src/main/java/Battle_System/UseCase/Battle/Battle_InputData.java
@@ -1,0 +1,31 @@
+package Battle_System.UseCase.Battle;
+
+import Battle_System.Entity.Monster;
+import Battle_System.Entity.User;
+
+/**
+ * The Input Data for the Battle Use Case.
+ */
+public class Battle_InputData {
+    private final User user;
+    private final Monster monster;
+    private final boolean resultOfQuiz;
+
+    public Battle_InputData(User user, Monster monster,  boolean resultOfQuiz) {
+        this.user = user;
+        this.monster = monster;
+        this.resultOfQuiz = resultOfQuiz;
+    }
+
+    User getUser() {
+        return user;
+    }
+
+    Monster getMonster() {
+        return monster;
+    }
+
+    boolean getResultOfQuiz() {
+        return resultOfQuiz;
+    }
+}

--- a/src/main/java/Battle_System/UseCase/Battle/Battle_Interactor.java
+++ b/src/main/java/Battle_System/UseCase/Battle/Battle_Interactor.java
@@ -1,0 +1,72 @@
+package Battle_System.UseCase.Battle;
+
+import Battle_System.Entity.Monster;
+import Battle_System.Entity.Spells;
+import Battle_System.Entity.User;
+
+public class Battle_Interactor implements Battle_InputBoundary {
+    private final BattleUserDataAccessInterface userDataAccessObject;
+    private final Battle_OutputBoundary battlePresenter;
+
+    public Battle_Interactor(BattleUserDataAccessInterface userDataAccessObject, Battle_OutputBoundary battleOutputBoundary) {
+        this.userDataAccessObject = userDataAccessObject;
+        this.battlePresenter = battleOutputBoundary;
+    }
+
+    /**
+     * This is the final method that would be called in ca, if the user choose "FIGHT" then this method will lead to the
+     * fight method.
+     */
+    @Override
+    public void execute(Battle_InputData inputData) {
+        final User user = inputData.getUser();
+        final Monster monster = inputData.getMonster();
+        // TODO:Not sure if I need to create boolean or just use a method to get the boolean from DAO,
+        //  since I don't have the DAO rn, I will just use the boolean for now.
+        final boolean resultOfQuiz = inputData.getResultOfQuiz();
+
+        // User's turn
+        UserTurn(user, monster, resultOfQuiz);
+        // Prepare final output
+        Battle_OutputData output = new Battle_OutputData(user, monster);
+        // Check if monster is defeated
+        if (!monster.isAlive()) {
+            battlePresenter.prepareWinView(output);
+            return;
+        }
+        // Monster's turn
+        MonsterTurn(user, monster);
+        // Prepare final output
+        output = new Battle_OutputData(user, monster);
+        // Present final result
+        if (!user.isAlive()) {
+            battlePresenter.prepareLossView(output);
+        }
+    }
+
+    /**
+     * Monster's turn to attack the user, monster will randomly choose a spell and then attack.
+     */
+    private void MonsterTurn(User user, Monster monster) {
+        Spells spell = monster.chooseSpell();
+        double DMG = monster.attack(spell);
+        user.HPDecrease(DMG);
+        // notify presenter to update the view (After the User attack)
+        Battle_OutputData turnOutput = new Battle_OutputData(user, monster);
+        battlePresenter.updateUserTurnState(turnOutput);
+    }
+
+    /**
+     * User's turn to attack the monster.
+     */
+    private void UserTurn(User user, Monster monster, boolean resultOfQuiz) {
+        double DMG = 0;
+        if(resultOfQuiz){
+            DMG = user.getDMG();
+        }
+        monster.HPDecrease(DMG);
+        // notify presenter to update the view (After the User attack)
+        Battle_OutputData turnOutput = new Battle_OutputData(user, monster);
+        battlePresenter.updateUserTurnState(turnOutput);
+    }
+}

--- a/src/main/java/Battle_System/UseCase/Battle/Battle_OutputBoundary.java
+++ b/src/main/java/Battle_System/UseCase/Battle/Battle_OutputBoundary.java
@@ -1,0 +1,31 @@
+package Battle_System.UseCase.Battle;
+
+public interface Battle_OutputBoundary {
+    /**
+     * Updates the Monster state during combat (called after each turn).
+     */
+    void updateMonsterTurnState(Battle_OutputData outputData);
+
+    /**
+     * Updates the User state during combat (called after each turn).
+     */
+    void updateUserTurnState(Battle_OutputData outputData);
+
+    /**
+     * Prepares the Win view for the Battle Use Case.
+     * @param outputData the output data
+     */
+    void prepareWinView(Battle_OutputData outputData);
+
+    /**
+     * Prepares the Loss view for the Battle Use Case.
+     * @param outputData the output data
+     */
+    void prepareLossView(Battle_OutputData outputData);
+
+    /**
+     * Prepares the Quiz view for the Battle Use Case.
+     * @param outputData the output data
+     */
+    void prepareQuizView(Battle_OutputData outputData);
+}

--- a/src/main/java/Battle_System/UseCase/Battle/Battle_OutputData.java
+++ b/src/main/java/Battle_System/UseCase/Battle/Battle_OutputData.java
@@ -1,0 +1,31 @@
+package Battle_System.UseCase.Battle;
+
+import Battle_System.Entity.Monster;
+import Battle_System.Entity.User;
+
+public class Battle_OutputData {
+    private final User user;
+    private final Monster monster;
+
+    public Battle_OutputData(User user, Monster monster) {
+        this.user = user;
+        this.monster = monster;
+        boolean battleEnded = !user.isAlive() || !monster.isAlive();
+    }
+
+    public User getUser() {
+        return user;
+    }
+
+    public Monster getMonster() {
+        return monster;
+    }
+
+    public double getUserHP() {
+        return user.getHP();
+    }
+
+    public double getMonsterHP() {
+        return monster.getHP();
+    }
+}

--- a/src/main/java/Battle_System/View/Battle_View.java
+++ b/src/main/java/Battle_System/View/Battle_View.java
@@ -1,0 +1,234 @@
+package Battle_System.View;
+
+import Battle_System.Interface_Adapter.Battle.Battle_Controller;
+import Battle_System.Interface_Adapter.Battle.Battle_State;
+import Battle_System.Interface_Adapter.Battle.Battle_ViewModel;
+import Battle_System.Interface_Adapter.ViewManagerModel;
+
+import javax.swing.*;
+import java.awt.*;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.beans.PropertyChangeEvent;
+import java.beans.PropertyChangeListener;
+
+/**
+ * The View for the Battle Use Case.
+ * Displays the battle interface and handles user interactions.
+ */
+public class Battle_View extends JPanel implements ActionListener, PropertyChangeListener {
+    private final String viewName = "Battle";
+    private final Battle_ViewModel viewModel;
+    private final ViewManagerModel viewManagerModel;
+    private Battle_Controller battleController;
+
+    private final Quiz_ViewModel quizViewModel;
+
+    // UI Components
+    private final JLabel titleLabel;
+    private final JLabel userHpLabel;
+    private final JLabel monsterNameLabel;
+    private final JLabel monsterHpLabel;
+    private final JTextArea battleMessageArea;
+    private final JButton attackButton;
+
+
+    public Battle_View(Battle_ViewModel battleViewModel, ViewManagerModel viewManagerModel, Quiz_ViewModel quizViewModel) {
+        this.viewModel = battleViewModel;
+        this.viewManagerModel = viewManagerModel;
+        this.quizViewModel = quizViewModel;
+        this.viewModel.addPropertyChangeListener(this);
+
+        // Initialize UI components
+        titleLabel = new JLabel("Battle", SwingConstants.CENTER);
+        titleLabel.setFont(new Font("Arial", Font.BOLD, 24));
+
+        userHpLabel = new JLabel("HP: N/A");
+        monsterNameLabel = new JLabel("Monster: N/A");
+        monsterHpLabel = new JLabel("HP: N/A");
+
+        battleMessageArea = new JTextArea(5, 30);
+        battleMessageArea.setEditable(false);
+        battleMessageArea.setLineWrap(true);
+        battleMessageArea.setWrapStyleWord(true);
+        battleMessageArea.setText("Battle is ready to begin...");
+
+        attackButton = new JButton("Attack");
+
+        // Add action listeners
+        attackButton.addActionListener(this);
+
+        // Layout setup
+        setupLayout();
+    }
+
+    /**
+     * Sets up the layout of the view.
+     */
+    private void setupLayout() {
+        setLayout(new BorderLayout(10, 10));
+        setBorder(BorderFactory.createEmptyBorder(20, 20, 20, 20));
+
+        // Title panel
+        JPanel titlePanel = new JPanel();
+        titlePanel.add(titleLabel);
+        add(titlePanel, BorderLayout.NORTH);
+
+        // Center panel with battle info
+        JPanel centerPanel = new JPanel(new GridLayout(3, 1, 10, 10));
+
+        // User info panel
+        JPanel userPanel = new JPanel(new GridLayout(2, 1));
+        userPanel.setBorder(BorderFactory.createTitledBorder("Player"));
+        userPanel.add(userHpLabel);
+
+        // Monster info panel
+        JPanel monsterPanel = new JPanel(new GridLayout(2, 1));
+        monsterPanel.setBorder(BorderFactory.createTitledBorder("Monster"));
+        monsterPanel.add(monsterNameLabel);
+        monsterPanel.add(monsterHpLabel);
+
+        // Battle message panel
+        JPanel messagePanel = new JPanel(new BorderLayout());
+        messagePanel.setBorder(BorderFactory.createTitledBorder("Battle Log"));
+        JScrollPane scrollPane = new JScrollPane(battleMessageArea);
+        messagePanel.add(scrollPane, BorderLayout.CENTER);
+
+        centerPanel.add(userPanel);
+        centerPanel.add(monsterPanel);
+        centerPanel.add(messagePanel);
+
+        add(centerPanel, BorderLayout.CENTER);
+
+        // Button panel
+        JPanel buttonPanel = new JPanel(new FlowLayout());
+        buttonPanel.add(attackButton);
+        add(buttonPanel, BorderLayout.SOUTH);
+    }
+
+    /**
+     * Sets the controller for this view.
+     */
+    public void setBattleController(Battle_Controller controller) {
+        this.battleController = controller;
+    }
+
+    /**
+     * Returns the view name.
+     */
+    public String getViewName() {
+        return viewName;
+    }
+
+    /**
+     * Invoked when an action occurs.
+     *
+     * @param e the event to be processed
+     */
+    @Override
+    public void actionPerformed(ActionEvent e) {
+        if (e.getSource() == attackButton) {
+            handleAttackButton();
+        }
+    }
+
+    /**
+     * Handles the attack button click.
+     */
+    private void handleAttackButton() {
+        Battle_State state = viewModel.getState();
+
+        if (state.isBattleEnded()) {
+            JOptionPane.showMessageDialog(this,
+                    "Battle has already ended!",
+                    "Battle Over",
+                    JOptionPane.INFORMATION_MESSAGE);
+            return;
+        }
+
+        if (battleController != null && state.getUser() != null && state.getMonster() != null) {
+            // Disable attack button
+            attackButton.setEnabled(false);
+
+            // Debug: Check what we're passing
+            System.out.println("Battle_View - Switching to Quiz");
+            System.out.println("User: " + state.getUser());
+            System.out.println("Monster: " + state.getMonster());
+
+            // Pass user and monster to Quiz state
+            quizViewModel.getState().setUser(state.getUser());
+            quizViewModel.getState().setMonster(state.getMonster());
+
+            // Debug: Verify quiz state
+            System.out.println("Quiz State User: " + quizViewModel.getState().getUser());
+            System.out.println("Quiz State Monster: " + quizViewModel.getState().getMonster());
+
+            // Switch to Quiz view
+            viewManagerModel.setState("Quiz");
+            viewManagerModel.firePropertyChange();
+            // Buttons will be re-enabled in propertyChange if battle continues
+        } else {
+            JOptionPane.showMessageDialog(this,
+                    "Battle is not properly initialized!",
+                    "Error",
+                    JOptionPane.ERROR_MESSAGE);
+        }
+    }
+
+    /**
+     * This method gets called when a bound property is changed.
+     *
+     * @param evt A PropertyChangeEvent object describing the event source
+     *            and the property that has changed.
+     */
+    @Override
+    public void propertyChange(PropertyChangeEvent evt) {
+        if ("state".equals(evt.getPropertyName())) {
+            Battle_State state = viewModel.getState();
+            updateDisplay(state);
+        }
+    }
+
+    /**
+     * Updates all display elements based on the current state.
+     */
+    private void updateDisplay(Battle_State state) {
+        // Update user info
+        if (state.getUser() != null) {
+            userHpLabel.setText(String.format("HP: %.1f", state.getUserHp()));
+        }
+
+        // Update monster info
+        if (state.getMonster() != null) {
+            monsterNameLabel.setText("Monster: " + state.getMonsterName());
+            monsterHpLabel.setText(String.format("HP: %.1f", state.getMonsterHP()));
+        }
+
+        // Update battle message
+        if (!state.getBattleMessage().isEmpty()) {
+            battleMessageArea.append("\n" + state.getBattleMessage());
+
+            // Auto-scroll to bottom
+            battleMessageArea.setCaretPosition(battleMessageArea.getDocument().getLength());
+        }
+
+        // Handle battle end
+        if (state.isBattleEnded()) {
+            attackButton.setEnabled(false);
+            // Show result dialog
+            String title = state.isUserWon() ? "Victory!" : "Defeat!";
+            int messageType = state.isUserWon() ? JOptionPane.INFORMATION_MESSAGE : JOptionPane.WARNING_MESSAGE;
+
+            JOptionPane.showMessageDialog(this,
+                    state.getBattleMessage(),
+                    title,
+                    messageType);
+        } else {
+            // Battle continues - re-enable buttons
+            attackButton.setEnabled(true);
+        }
+    }
+}
+
+
+

--- a/src/main/java/Battle_System/View/Quiz_State.java
+++ b/src/main/java/Battle_System/View/Quiz_State.java
@@ -1,0 +1,37 @@
+package Battle_System.View;
+
+import Battle_System.Entity.Monster;
+import Battle_System.Entity.User;
+
+/**
+ * State object for the Quiz View.
+ */
+public class Quiz_State {
+    private User user = null;
+    private Monster monster = null;
+    private boolean quizResult = false;
+
+    public User getUser() {
+        return user;
+    }
+
+    public void setUser(User user) {
+        this.user = user;
+    }
+
+    public Monster getMonster() {
+        return monster;
+    }
+
+    public void setMonster(Monster monster) {
+        this.monster = monster;
+    }
+
+    public boolean getQuizResult() {
+        return quizResult;
+    }
+
+    public void setQuizResult(boolean quizResult) {
+        this.quizResult = quizResult;
+    }
+}

--- a/src/main/java/Battle_System/View/Quiz_View.java
+++ b/src/main/java/Battle_System/View/Quiz_View.java
@@ -1,0 +1,169 @@
+package Battle_System.View;
+
+import Battle_System.Interface_Adapter.Battle.Battle_Controller;
+import Battle_System.Interface_Adapter.ViewManagerModel;
+
+import javax.swing.*;
+import java.awt.*;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.beans.PropertyChangeEvent;
+import java.beans.PropertyChangeListener;
+
+/**
+ * The View for the Quiz Use Case.
+ * Displays a simple quiz with True and False buttons.
+ */
+public class Quiz_View extends JPanel implements ActionListener, PropertyChangeListener {
+    private final String viewName = "Quiz";
+    private final Quiz_ViewModel viewModel;
+    private final ViewManagerModel viewManagerModel;
+    private Battle_Controller battleController;
+
+    // UI Components
+    private final JLabel titleLabel;
+    private final JLabel questionLabel;
+    private final JButton trueButton;
+    private final JButton falseButton;
+
+    public Quiz_View(Quiz_ViewModel quizViewModel, ViewManagerModel viewManagerModel) {
+        this.viewModel = quizViewModel;
+        this.viewManagerModel = viewManagerModel;
+        this.viewModel.addPropertyChangeListener(this);
+
+        // Initialize UI components
+        titleLabel = new JLabel("Quiz Time!", SwingConstants.CENTER);
+        titleLabel.setFont(new Font("Arial", Font.BOLD, 24));
+
+        questionLabel = new JLabel("Answer the question:", SwingConstants.CENTER);
+        questionLabel.setFont(new Font("Arial", Font.PLAIN, 18));
+
+        trueButton = new JButton("TRUE");
+        trueButton.setFont(new Font("Arial", Font.BOLD, 16));
+        trueButton.setPreferredSize(new Dimension(150, 50));
+
+        falseButton = new JButton("FALSE");
+        falseButton.setFont(new Font("Arial", Font.BOLD, 16));
+        falseButton.setPreferredSize(new Dimension(150, 50));
+
+        // Add action listeners
+        trueButton.addActionListener(this);
+        falseButton.addActionListener(this);
+
+        // Layout setup
+        setupLayout();
+    }
+
+    /**
+     * Sets up the layout of the view.
+     */
+    private void setupLayout() {
+        setLayout(new BorderLayout(10, 10));
+        setBorder(BorderFactory.createEmptyBorder(50, 50, 50, 50));
+
+        // Title panel
+        JPanel titlePanel = new JPanel();
+        titlePanel.add(titleLabel);
+        add(titlePanel, BorderLayout.NORTH);
+
+        // Question panel
+        JPanel questionPanel = new JPanel();
+        questionPanel.add(questionLabel);
+        add(questionPanel, BorderLayout.CENTER);
+
+        // Button panel
+        JPanel buttonPanel = new JPanel(new FlowLayout(FlowLayout.CENTER, 20, 20));
+        buttonPanel.add(trueButton);
+        buttonPanel.add(falseButton);
+        add(buttonPanel, BorderLayout.SOUTH);
+    }
+
+    /**
+     * Sets the battle controller for this view.
+     */
+    public void setBattleController(Battle_Controller controller) {
+        this.battleController = controller;
+    }
+
+    /**
+     * Returns the view name.
+     */
+    public String getViewName() {
+        return viewName;
+    }
+
+    /**
+     * Invoked when an action occurs.
+     */
+    @Override
+    public void actionPerformed(ActionEvent e) {
+        Quiz_State state = viewModel.getState();
+
+        if (e.getSource() == trueButton) {
+            handleAnswer(true, state);
+        } else if (e.getSource() == falseButton) {
+            handleAnswer(false, state);
+        }
+    }
+
+    /**
+     * Handles the answer button click.
+     */
+    private void handleAnswer(boolean answer, Quiz_State state) {
+        // Disable buttons after selection
+        trueButton.setEnabled(false);
+        falseButton.setEnabled(false);
+
+        // Update state with quiz result
+        state.setQuizResult(answer);
+
+        // Debug: Check what we have
+        System.out.println("Quiz_View - handleAnswer called");
+        System.out.println("battleController: " + battleController);
+        System.out.println("user: " + state.getUser());
+        System.out.println("monster: " + state.getMonster());
+
+        // Call battle controller to execute battle with quiz result
+        if (battleController == null) {
+            JOptionPane.showMessageDialog(this,
+                    "Battle controller is not set!",
+                    "Error",
+                    JOptionPane.ERROR_MESSAGE);
+            trueButton.setEnabled(true);
+            falseButton.setEnabled(true);
+            return;
+        }
+
+        if (state.getUser() == null || state.getMonster() == null) {
+            JOptionPane.showMessageDialog(this,
+                    "User or Monster is null!\nUser: " + state.getUser() + "\nMonster: " + state.getMonster(),
+                    "Error",
+                    JOptionPane.ERROR_MESSAGE);
+            trueButton.setEnabled(true);
+            falseButton.setEnabled(true);
+            return;
+        }
+
+        // Execute battle with quiz result
+        battleController.execute(state.getUser(), state.getMonster(), answer);
+
+        // Switch back to Battle view
+        viewManagerModel.setState("Battle");
+        viewManagerModel.firePropertyChange();
+
+        // Re-enable buttons for next quiz
+        trueButton.setEnabled(true);
+        falseButton.setEnabled(true);
+    }
+
+    /**
+     * This method gets called when a bound property is changed.
+     */
+    @Override
+    public void propertyChange(PropertyChangeEvent evt) {
+        if ("state".equals(evt.getPropertyName())) {
+            Quiz_State state = viewModel.getState();
+            // Can update UI based on state if needed
+        }
+    }
+}

--- a/src/main/java/Battle_System/View/Quiz_ViewModel.java
+++ b/src/main/java/Battle_System/View/Quiz_ViewModel.java
@@ -1,0 +1,12 @@
+package Battle_System.View;
+
+import Battle_System.Interface_Adapter.ViewModel;
+
+public class Quiz_ViewModel extends ViewModel<Quiz_State> {
+
+    public Quiz_ViewModel() {
+        super("Quiz");
+        setState(new Quiz_State());
+    }
+}
+


### PR DESCRIPTION
The previous one has the Merging conflicts, this is the new version

This Pull Request introduces the Battle Use Case. However, this branch currently includes both the Battle Use Case and the Inventory Use Case. After this PR is merged, the Inventory Use Case should continue development in a separate branch.

Please review this PR and leave the feedbacks for the code, along with any suggestions for how we should handle the remaining TODO items!

This PR follows the Clean Architecture (CA) style, but it does not yet implement view switching between different screens. There are several TODO items remaining for this PR:

## TODO in Data Access

- [ ] The `InMemoryBattleDataAccess` file will likely be used across multiple parts of the project, so we should finalize a stable version of it. The current DAO implementation in this branch only stores the `User` and the `Monster`, which will need to be expanded or refactored once the shared version is established. (My version is only for lab in Nov.17)

- [ ] For the `BattleUserDataAccessInterface`, I am not fully certain whether the methods defined are appropriate or whether the stored data matches our intended structure. This may need revision later.

## TODO in the Entity Layer

- [ ] Several classes still require overridden methods, which I have marked as TODO. I will confirm with the TA whether these overrides are mandatory. If so, I will add the required methods.

## TODO in the Interface Adapter Layer
- [ ] The View Manager and the view model is not yet implemented. I am still trying to figure out how to code it. It will be needed to switch from the Battle View back to the Map Movement View. Once the map system is complete, we will also need to integrate its ViewModel.
- [ ] For the Presenter, I originally attempted to return a detailed message describing the spell used by the monster during its turn. However, implementing this properly seems to require adding a `Spell` class and passing `Spell` as a parameter to the Presenter method — which violates the Dependency Rule. I am still exploring solutions. If no approach is found, the Presenter will instead show only HP updates in the battle log without detailed spell descriptions.
<img width="750" height="736" alt="image" src="https://github.com/user-attachments/assets/2c490564-5dbb-401b-8fac-2fc7cbec23d5" />
